### PR TITLE
Fix null array offset deprecation on PHP 8.5 in Select::getRawValue()

### DIFF
--- a/HTML/QuickForm2/Element/Select.php
+++ b/HTML/QuickForm2/Element/Select.php
@@ -180,7 +180,7 @@ class HTML_QuickForm2_Element_Select extends HTML_QuickForm2_Element
 
         $values = [];
         foreach ($this->values as $value) {
-            if (!$this->data['intrinsic_validation'] || !empty($this->possibleValues[$value])) {
+            if (!$this->data['intrinsic_validation'] || !empty($this->possibleValues[(string) $value])) {
                 $values[] = $value;
             }
         }


### PR DESCRIPTION
On PHP 8.5, `Select::getRawValue()` triggers:

> Using null as an array offset is deprecated, use an empty string instead

at `HTML/QuickForm2/Element/Select.php:183`. When a select's value is `null` (e.g. an empty/unselected option, or a datasource returning `null`), the loop does `$this->possibleValues[$value]` with `$value === null`, using `null` as an array offset.

This casts `$value` to string in the offset lookup. `null` becomes `''` — which PHP already coerced it to implicitly when used as an array key — so behavior is unchanged on all supported PHP versions, and the 8.5 deprecation no longer fires. (Numeric option values are unaffected: `(string) 5` and `5` resolve to the same array key.)

This deprecation is fatal under strict mode, so any form containing a `<select>` fails to render on PHP 8.5.
